### PR TITLE
Add `EOS_DISABLE` define and server flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ Here are some automated value getters which you might find helpful:
 
 Do note that any of these tokens could be missing for any reason and OpenEOS will print a warning in that case. Notably, if the user runs the app from outside the Epic Games Store Launcher, there will be no chance for it to pass the command line arguments in.
 
+### Disabling at Compile Time
+
+You can now use a scripting define symbol in your project called `EOS_DISABLE` to stop the SDK (and the OpenEOS wrapper library) from being included at compile time. You can do this by navigating to the Project Settings and heading down to the *Scripting Define Symbols* section, where you can add defines for each platform. Alternatively, you can use any of the methods [described here](https://docs.unity3d.com/Manual/CustomScriptingSymbols.html) to set scripting defines via code. A custom Editor plugin that manages building for different platforms should also allow you set custom defines.
+
+**Note:** Since you are required to interface with either OpenEOS or the SDK directly using your own manager code, it is expected that you also check for `EOS_DISABLE` whenever you import or interact with anything provided by this package if you intend use the define symbol. Example usage:
+
+```cs
+#if !EOS_DISABLE
+using RobProductions.OpenEOS;
+using Epic.OnlineServices;
+using Epic.OnlineServices.Auth;
+using Epic.OnlineServices.Achievements;
+using Epic.OnlineServices.Connect;
+#endif
+```
+
 ## Installation
 
 ### Recommended Installation

--- a/Runtime/CoreLayer/EOSCore.cs
+++ b/Runtime/CoreLayer/EOSCore.cs
@@ -201,8 +201,8 @@ namespace RobProductions.OpenEOS
 				DeploymentId = initSet.deploymentID,
 				Flags = initSet.platformFlags,
 				EncryptionKey = encryptionKey,
-				//CacheDirectory = 
-				//IsServer = false,
+				IsServer = initSet.isServerFlag,
+				//CacheDirectory = ???,
 				//OverrideCountryCode = false,
 				//OverrideLocaleCode = false,
 				//TickBudgetInMilliseconds = 0            
@@ -261,7 +261,6 @@ namespace RobProductions.OpenEOS
 		}
 
 		//EDITOR UTIL
-
 
 		//Snippet provided by EOS Sample code
 		//https://dev.epicgames.com/docs/epic-online-services/eos-get-started/eossdkc-sharp-getting-started

--- a/Runtime/CoreLayer/EOSInitSet.cs
+++ b/Runtime/CoreLayer/EOSInitSet.cs
@@ -76,6 +76,12 @@ namespace RobProductions.OpenEOS
 		/// Will be treated as null if empty string.
 		/// </summary>
 		public string encryptionKey = "";
+
+		/// <summary>
+		/// Optional: If true, EOS will launch assuming the client is a dedicated game server.
+		/// Use false for local client, which is most likely what you want.
+		/// </summary>
+		public bool isServerFlag = false;
 	}
 }
 

--- a/Runtime/robproductions.openeos.runtime.asmdef
+++ b/Runtime/robproductions.openeos.runtime.asmdef
@@ -1,3 +1,16 @@
 {
-	"name": "robproductions.openeos.runtime"
+    "name": "robproductions.openeos.runtime",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "!EOS_DISABLE"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "com.robproductions.openeos",
-  "version": "2.0.0",
-  "displayName": "OpenEOS",
-  "description": "A lightweight & open-source port of the Epic Online Services (EOS) SDK in Unity Package format, with minor enhancements to provide a smoother integration between Unity and EOS.",
-  "unity": "2020.3",
-  "changelogUrl": "https://github.com/RobProductions/OpenEOS",
-  "licensesUrl": "https://github.com/RobProductions/OpenEOS/blob/main/LICENSE",
-  "license": "MIT License",
-  "keywords": [
-    "epic",
-	"epicgames",
-	"eos",
-	"sdk",
-	"integration"
-  ],
-  "author": {
-    "name": "RobProductions",
-    "url": "https://github.com/RobProductions"
-  }
+	"name": "com.robproductions.openeos",
+	"version": "2.1.0",
+	"displayName": "OpenEOS",
+	"description": "A lightweight & open-source port of the Epic Online Services (EOS) SDK in Unity Package format, with minor enhancements to provide a smoother integration between Unity and EOS.",
+	"unity": "2020.3",
+	"changelogUrl": "https://github.com/RobProductions/OpenEOS",
+	"licensesUrl": "https://github.com/RobProductions/OpenEOS/blob/main/LICENSE",
+	"license": "MIT License",
+	"keywords": [
+		"epic",
+		"epicgames",
+		"eos",
+		"sdk",
+		"integration"
+	],
+	"author": {
+		"name": "RobProductions",
+		"url": "https://github.com/RobProductions"
+	}
 }


### PR DESCRIPTION
- Added `EOS_DISABLE` to restrict the assembly definition from building while that symbol is defined
- Added `isServerFlag` to EOSInitSet as an additional option to pass into EOSCore.Init()
- Updated README for clarity on how to use the new scripting define